### PR TITLE
PauseandResume

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,10 +1,10 @@
-//chatmessage
+//New Chatmessage.tsx
 import React, { useState, useCallback } from "react";
 import ChatLogo from "../assets/Genie.svg";
 import VerifyAuth from "../pages/Home/verifyAuth";
 import { askBart, verifyOTP } from "../Api/CommonApi";
 import OtpInputCard from "./ui/OtpInputCard";
-import { speakText, stopSpeaking, createTimestamp } from "../utils/chatUtils";
+import { speakText, stopSpeaking, createTimestamp, resumeSpeaking, cancelSpeaking, getCurrentSpeakingMessageId, setActiveMessageComponent } from "../utils/chatUtils";
 import ChatButtonCard from "./ui/ChatButtonCard";
 import UserCard from "./ui/UserCard";
 import TicketCard from "./ui/ticketcard";
@@ -24,15 +24,35 @@ const ChatMessage: React.FC<ChatMessageProps> = React.memo(
     const [utterance, setUtterance] = useState<SpeechSynthesisUtterance | null>(
       null
     );
+    const [isPaused, setIsPaused] = useState(false);
+    const messageId = message.history_id || message.timestamp;
 
-    // Clean up speech synthesis when component unmounts
+    // Add resetSpeakingState function
+    const resetSpeakingState = useCallback(() => {
+      setIsSpeaking(false);
+      setIsPaused(false);
+      setUtterance(null); 
+    }, []);
+
+    // Register this component as active when mounted
     React.useEffect(() => {
+      setActiveMessageComponent({ resetSpeakingState });
+      return () => {
+        if (getCurrentSpeakingMessageId() === messageId) {
+          cancelSpeaking();
+        }
+      };
+    }, [messageId, resetSpeakingState]);
+
+    React.useEffect(() => {
+      // Cleanup function for component unmount and page refresh
       return () => {
         if (utterance) {
           window.speechSynthesis.cancel();
+          resetSpeakingState();
         }
       };
-    }, [utterance]);
+    }, [utterance, resetSpeakingState]);
 
     const handleVerificationComplete = useCallback(async () => {
       setShowAuthVideoCard(false);
@@ -177,27 +197,42 @@ const ChatMessage: React.FC<ChatMessageProps> = React.memo(
     };
 
     const handleSpeak = () => {
-      if (isSpeaking) {
-        stopSpeaking();
-        setIsSpeaking(false);
-        setUtterance(null);
-      } else {
-        const newUtterance = speakText(message.text);
+      const currentSpeakingId = getCurrentSpeakingMessageId();
+      
+      // If we're already speaking this message
+      if (currentSpeakingId === messageId && isSpeaking) {
+        if (isPaused) {
+          resumeSpeaking();
+          setIsPaused(false);
+        } else {
+          stopSpeaking();
+          setIsPaused(true);
+        }
+        return;
+      }
+
+      // Reset states before starting new speech
+      setIsSpeaking(false);
+      setIsPaused(false);
+      
+      // Cancel any existing speech
+      cancelSpeaking();
+      
+      // Start new speech after a small delay to ensure previous speech is cancelled
+      setTimeout(() => {
+        const newUtterance = speakText(message.text, messageId);
 
         newUtterance.onend = () => {
-          setIsSpeaking(false);
-          setUtterance(null);
+          resetSpeakingState();
         };
 
         newUtterance.onerror = () => {
-          setIsSpeaking(false);
-          setUtterance(null);
+          resetSpeakingState();
         };
 
-        window.speechSynthesis.speak(newUtterance);
-        setUtterance(newUtterance);
         setIsSpeaking(true);
-      }
+        setUtterance(newUtterance);
+      }, 100);
     };
 
     console.log("Message data:", {
@@ -342,9 +377,9 @@ const ChatMessage: React.FC<ChatMessageProps> = React.memo(
               className={`p-1 rounded transition-colors hover:bg-gray-100 
                 ${isSpeaking ? "text-blue-600" : ""}`}
               onClick={handleSpeak}
-              aria-label={isSpeaking ? "Stop speaking" : "Speak message"}
+              aria-label={isSpeaking ? (isPaused ? "Resume speaking" : "Pause speaking") : "Speak message"}
             >
-              {isSpeaking ? (
+              {isSpeaking && !isPaused ? (
                 <SpeakerX size={16} weight="fill" />
               ) : (
                 <SpeakerHigh size={16} />

--- a/src/components/VoiceChatCard.tsx
+++ b/src/components/VoiceChatCard.tsx
@@ -1,4 +1,4 @@
-"use client";
+//VoiceChatCard.tsx"use client";
 
 import avatar from "../assets/avatar.gif";
 
@@ -35,3 +35,4 @@ export default function VoiceChatCard({ text = "" }: VoiceChatCardProps) {
     </div>
   );
 }
+

--- a/src/utils/chatUtils.ts
+++ b/src/utils/chatUtils.ts
@@ -1,168 +1,4 @@
-// import DOMPurify from "dompurify";
-
-// // Add type declarations at the top of the file
-// declare global {
-//   interface Window {
-//     SpeechRecognition?: new () => SpeechRecognition;
-//     webkitSpeechRecognition?: new () => SpeechRecognition;
-//   }
-// }
-
-// interface SpeechRecognitionResult {
-//   isFinal: boolean;
-//   [index: number]: {
-//     transcript: string;
-//     confidence: number;
-//   };
-// }
-
-// interface SpeechRecognitionEvent {
-//   results: SpeechRecognitionResult[];
-//   resultIndex: number;
-// }
-
-// interface SpeechRecognitionError {
-//   error: string;
-//   message: string;
-// }
-
-// interface SpeechRecognition extends EventTarget {
-//   continuous: boolean;
-//   interimResults: boolean;
-//   lang: string;
-//   onresult: (event: SpeechRecognitionEvent) => void;
-//   onend: () => void;
-//   onerror: (event: SpeechRecognitionError) => void;
-//   start: () => void;
-//   stop: () => void;
-// }
-
-// export const createTimestamp = (): string => {
-//   return new Date().toISOString();
-// };
-
-// const createMarkup = (text: string) => {
-//   // First convert all dashes to dots
-//   let processedText = text.replace(/^-/gm, "•");
-
-//   // Convert markdown headers (##) to HTML
-//   processedText = processedText.replace(
-//     /^## (.*$)/gm,
-//     '<h2 class="text-xl font-bold ">$1</h2>'
-//   );
-
-//   // Convert bullet points to list items
-//   processedText = processedText.replace(
-//     /^•\s+(.*$)/gm,
-//     '<li class="relative">• $1</li>'
-//   );
-
-//   // Convert numbered lists
-//   processedText = processedText.replace(
-//     /^\d+\.\s+(.*$)/gm,
-//     (match) => `<li>${match}</li>`
-//   );
-
-//   // Convert indented bullet points
-//   processedText = processedText.replace(/^[ ]{3}•\s+(.*$)/gm, "<li>• $1</li>");
-
-//   // Convert newlines to <br> tags (after handling lists)
-//   processedText = processedText.replace(/\n/g, "<br>");
-
-//   // Wrap lists in ul tags (modified to remove extra spacing)
-//   processedText = processedText.replace(
-//     /(<li.*?>.*?<\/li>\n?)+/gs,
-//     (match) => `<ul class="list-none ">${match.replace(/\n/g, "")}</ul>`
-//   );
-
-//   // Convert links [text](url) to anchor tags
-//   processedText = processedText.replace(
-//     /\[(.*?)\]\((.*?)\)/g,
-//     '<a href="$2" target="_blank" class="text-blue-500 hover:text-blue-700">$1</a>'
-//   );
-
-//   // Sanitize the HTML to prevent XSS attacks
-//   const sanitizedHtml = DOMPurify.sanitize(processedText, {
-//     ALLOWED_TAGS: ["h2", "ul", "li", "a", "br"],
-//     ALLOWED_ATTR: ["href", "target", "class"],
-//   });
-
-//   return {
-//     __html: sanitizedHtml,
-//   };
-// };
-
-// export const speakText = (text: string): SpeechSynthesisUtterance => {
-//   // Remove HTML tags from the text
-//   const cleanText = text.replace(/<[^>]*>/g, "");
-
-//   // Create speech synthesis instance
-//   const speech = new SpeechSynthesisUtterance();
-//   speech.text = cleanText;
-//   speech.volume = 1;
-//   speech.rate = 1;
-//   speech.pitch = 1;
-
-//   // Use the default voice
-//   const voices = window.speechSynthesis.getVoices();
-//   const englishVoice = voices.find((voice) => voice.lang.startsWith("en-"));
-//   if (englishVoice) {
-//     speech.voice = englishVoice;
-//   }
-
-//   // Cancel any ongoing speech
-//   window.speechSynthesis.cancel();
-
-//   // Return the utterance instance
-//   return speech;
-// };
-
-// // Function to stop speaking
-// export const stopSpeaking = () => {
-//   window.speechSynthesis.cancel();
-// };
-
-// // Speech Recognition setup
-// const SpeechRecognitionAPI =
-//   window.SpeechRecognition || window.webkitSpeechRecognition;
-// const recognition: SpeechRecognition | null = SpeechRecognitionAPI
-//   ? new SpeechRecognitionAPI()
-//   : null;
-
-// if (recognition) {
-//   recognition.continuous = true;
-//   recognition.interimResults = true;
-//   recognition.lang = "en-US";
-// }
-
-// export const startSpeechRecognition = (
-//   onResult: (text: string) => void,
-//   onEnd: () => void
-// ) => {
-//   if (!recognition) {
-//     console.error("Speech recognition is not supported in this browser");
-//     return false;
-//   }
-
-//   recognition.onresult = (event: SpeechRecognitionEvent) => {
-//     const transcript = Array.from(event.results)
-//       .map((result) => result[0].transcript)
-//       .join("");
-//     onResult(transcript);
-//   };
-
-//   recognition.onend = onEnd;
-//   recognition.start();
-//   return true;
-// };
-
-// export const stopSpeechRecognition = () => {
-//   if (recognition) {
-//     recognition.stop();
-//   }
-// };
-
-// export default createMarkup;
+//New chatUtils.ts
 
 import DOMPurify from "dompurify";
 
@@ -202,6 +38,11 @@ interface SpeechRecognition extends EventTarget {
   start: () => void;
   stop: () => void;
 }
+
+// Add these variables at the top of the file, after imports
+let currentUtterance: SpeechSynthesisUtterance | null = null;
+let currentMessageId: string | null = null;
+let activeMessageComponent: { resetSpeakingState: () => void } | null = null;
 
 export const createTimestamp = (): string => {
   return new Date().toISOString();
@@ -244,34 +85,72 @@ const createMarkup = (text: string) => {
   };
 };
 
-export const speakText = (text: string): SpeechSynthesisUtterance => {
-  // Remove HTML tags from the text
-  const cleanText = text.replace(/<[^>]*>/g, "");
+export const speakText = (text: string, messageId: string): SpeechSynthesisUtterance => {
+  // Clean the text - remove HTML tags and hyperlinks
+  let cleanText = text
+    // Remove HTML tags
+    .replace(/<[^>]*>/g, "")
+    // Remove markdown links [text](url) - keep only the text part
+    .replace(/\[(.*?)\]\(.*?\)/g, "$1")
+    // Remove URLs
+    .replace(/https?:\/\/\S+/g, "")
+    // Remove just the word "source" and any text after it on the same line
+    .replace(/source.*?(?=\n|$)/gi, "")
+    // Clean up extra spaces and line breaks
+    .replace(/\s+/g, " ")
+    .trim();
 
-  // Create speech synthesis instance
+  
+  // Create new speech synthesis instance
   const speech = new SpeechSynthesisUtterance();
   speech.text = cleanText;
   speech.volume = 1;
   speech.rate = 1;
   speech.pitch = 1;
+  speech.lang = 'en-US';
+  
+  // Update global state
+  currentUtterance = speech;
+  currentMessageId = messageId;
 
-  // Use the default voice
-  const voices = window.speechSynthesis.getVoices();
-  const englishVoice = voices.find((voice) => voice.lang.startsWith("en-"));
-  if (englishVoice) {
-    speech.voice = englishVoice;
+  try {
+    window.speechSynthesis.speak(speech);
+  } catch (error) {
+    console.error('Speech synthesis error:', error);
+    currentUtterance = null;
+    currentMessageId = null;
   }
 
-  // Cancel any ongoing speech
-  window.speechSynthesis.cancel();
-
-  // Return the utterance instance
   return speech;
 };
 
 // Function to stop speaking
 export const stopSpeaking = () => {
-  window.speechSynthesis.cancel();
+  if (currentUtterance) {
+    window.speechSynthesis.pause();
+  }
+};
+
+// Function to resume speaking
+export const resumeSpeaking = () => {
+  if (currentUtterance) {
+    window.speechSynthesis.resume();
+  }
+};
+
+export const cancelSpeaking = () => {
+  try {
+    window.speechSynthesis.cancel();
+    
+    if (activeMessageComponent) {
+      activeMessageComponent.resetSpeakingState();
+    }
+  } catch (error) {
+    console.error('Error cancelling speech:', error);
+  } finally {
+    currentUtterance = null;
+    currentMessageId = null;
+  }
 };
 
 // Speech Recognition setup
@@ -313,5 +192,18 @@ export const stopSpeechRecognition = () => {
     recognition.stop();
   }
 };
+
+export const getCurrentSpeakingMessageId = () => currentMessageId;
+
+export const setActiveMessageComponent = (component: { resetSpeakingState: () => void }) => {
+  activeMessageComponent = component;
+};
+
+// Add this at the top with other event listeners
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', () => {
+    window.speechSynthesis.cancel();
+  });
+}
 
 export default createMarkup;


### PR DESCRIPTION
Initially, the speaker played audio automatically and continued after a page refresh, with no pause or resume option. Now, users can pause and resume playback, continuing from where it stopped. Audio stops on refresh and plays only when explicitly triggered. Switching chats or responses allows independent playback controls .